### PR TITLE
Feature/occupancy checker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(mas_navigation_tools)
 add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
+    actionlib
+    message_generation
     geometry_msgs
     laser_geometry
     message_filters
@@ -20,10 +22,22 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(PCL 1.7 REQUIRED)
 
+add_action_files(DIRECTORY ros/action
+  FILES
+    OccupancyChecker.action
+)
+
+generate_messages(
+  DEPENDENCIES
+    geometry_msgs
+    actionlib_msgs
+)
+
 catkin_package(CATKIN_DEPENDS
     geometry_msgs
     nav_msgs
     std_msgs
+    actionlib_msgs
 )
 
 include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ install(PROGRAMS
   ros/scripts/pose_visualiser
   ros/scripts/save_base_map_poses_to_file
   ros/scripts/map_saver
+  ros/scripts/occupancy_checker
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,8 @@
   <depend>rospy</depend>
   <depend>rviz</depend>
 
+  <build_depend>actionlib</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
   <build_depend>laser_geometry</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>roslint</build_depend>
@@ -27,6 +29,8 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>pcl_ros</build_depend>
 
+  <exec_depend>actionlib</exec_depend>
+  <exec_depend>actionlib_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>

--- a/ros/action/OccupancyChecker.action
+++ b/ros/action/OccupancyChecker.action
@@ -1,0 +1,8 @@
+# Goal
+geometry_msgs/Point[] points
+float64 search_radius
+---
+# Result
+bool[] far_from_obstacle
+---
+# Empty Feedback

--- a/ros/launch/occupancy_checker.launch
+++ b/ros/launch/occupancy_checker.launch
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<launch>
+    <arg name="action_name" default="occupancy_checker"/>
+    <arg name="map_topic" default="/map"/>
+
+    <node pkg="mas_navigation_tools" type="occupancy_checker" name="occupancy_checker" output="screen" ns="mas_navigation_tools">
+        <param name="action_name" type="string" value="$(arg action_name)" />
+        <param name="map_topic" type="string" value="$(arg map_topic)" />
+    </node>
+</launch>

--- a/ros/scripts/occupancy_checker
+++ b/ros/scripts/occupancy_checker
@@ -6,7 +6,7 @@ import rospy
 import actionlib
 from nav_msgs.msg import OccupancyGrid
 from map_msgs.msg import OccupancyGridUpdate
-from mas_perception_msgs.msg import OccupancyCheckerAction, OccupancyCheckerResult
+from mas_navigation_tools.msg import OccupancyCheckerAction, OccupancyCheckerResult
 
 # This class is taken as is from: 
 # https://github.com/awesomebytes/occupancy_grid_python/blob/1034fc18912e57d4ba643ac547256dfbd4f5945b/src/occupancy_grid_python/occupancy_grid_impl.py#L1

--- a/ros/scripts/occupancy_checker
+++ b/ros/scripts/occupancy_checker
@@ -1,0 +1,254 @@
+#!/usr/bin/env python2
+from __future__ import print_function
+import numpy as np
+from itertools import product
+import rospy
+import actionlib
+from nav_msgs.msg import OccupancyGrid
+from map_msgs.msg import OccupancyGridUpdate
+from mas_perception_msgs.msg import OccupancyCheckerAction, OccupancyCheckerResult
+
+# This class is taken as is from: 
+# https://github.com/awesomebytes/occupancy_grid_python/blob/1034fc18912e57d4ba643ac547256dfbd4f5945b/src/occupancy_grid_python/occupancy_grid_impl.py#L1
+class OccupancyGridManager(object):
+    def __init__(self, topic, subscribe_to_updates=False):
+        # OccupancyGrid starts on lower left corner
+        self._grid_data = None
+        self._occ_grid_metadata = None
+        self._reference_frame = None
+        self._sub = rospy.Subscriber(topic, OccupancyGrid,
+                                     self._occ_grid_cb,
+                                     queue_size=1)
+        if subscribe_to_updates:
+            rospy.loginfo("Subscribing to updates!")
+            self._updates_sub = rospy.Subscriber(topic + '_updates',
+                                                 OccupancyGridUpdate,
+                                                 self._occ_grid_update_cb,
+                                                 queue_size=1)
+        rospy.loginfo("Waiting for '" +
+                      str(self._sub.resolved_name) + "'...")
+        while self._occ_grid_metadata is None and \
+                self._grid_data is None and not rospy.is_shutdown():
+            rospy.sleep(0.1)
+        rospy.loginfo("OccupancyGridManager for '" +
+                      str(self._sub.resolved_name) +
+                      "' initialized!")
+        rospy.loginfo("Height (y / rows): " + str(self.height) +
+                      ", Width (x / columns): " + str(self.width) +
+                      ", starting from bottom left corner of the grid. " + 
+                      " Reference_frame: " + str(self.reference_frame) +
+                      " origin: " + str(self.origin))
+
+    @property
+    def resolution(self):
+        return self._occ_grid_metadata.resolution
+
+    @property
+    def width(self):
+        return self._occ_grid_metadata.width
+
+    @property
+    def height(self):
+        return self._occ_grid_metadata.height
+
+    @property
+    def origin(self):
+        return self._occ_grid_metadata.origin
+
+    @property
+    def reference_frame(self):
+        return self._reference_frame
+
+    def _occ_grid_cb(self, data):
+        rospy.loginfo("Got a full OccupancyGrid update")
+        self._occ_grid_metadata = data.info
+        # Contains resolution, width & height
+        # np.set_printoptions(threshold=99999999999, linewidth=200)
+        # data comes in row-major order http://docs.ros.org/en/melodic/api/nav_msgs/html/msg/OccupancyGrid.html
+        # first index is the row, second index the column
+        self._grid_data = np.array(data.data,
+                                   dtype=np.int8).reshape(data.info.height,
+                                                          data.info.width)
+        self._reference_frame = data.header.frame_id
+        # print(self._grid_data)
+
+    def _occ_grid_update_cb(self, data):
+        rospy.loginfo("Got a partial OccupancyGrid update")
+        # x, y origin point of the update
+        # width and height of the update
+        # data, the update
+        # data comes in row-major order http://docs.ros.org/en/melodic/api/nav_msgs/html/msg/OccupancyGrid.html
+        # first index is the row, second index the column
+        data_np = np.array(data.data,
+                           dtype=np.int8).reshape(data.height, data.width)
+        self._grid_data[data.y:data.y +
+                        data.height, data.x:data.x + data.width] = data_np
+        # print(self._grid_data)
+
+    def get_world_x_y(self, costmap_x, costmap_y):
+        world_x = costmap_x * self.resolution + self.origin.position.x
+        world_y = costmap_y * self.resolution + self.origin.position.y
+        return world_x, world_y
+
+    def get_costmap_x_y(self, world_x, world_y):
+        costmap_x = int(
+            round((world_x - self.origin.position.x) / self.resolution))
+        costmap_y = int(
+            round((world_y - self.origin.position.y) / self.resolution))
+        return costmap_x, costmap_y
+
+    def get_cost_from_world_x_y(self, x, y):
+        cx, cy = self.get_costmap_x_y(x, y)
+        try:
+            return self.get_cost_from_costmap_x_y(cx, cy)
+        except IndexError as e:
+            raise IndexError("Coordinates out of grid (in frame: {}) x: {}, y: {} must be in between: [{}, {}], [{}, {}]. Internal error: {}".format(
+                self.reference_frame, x, y,
+                self.origin.position.x,
+                self.origin.position.x + self.height * self.resolution,
+                self.origin.position.y,
+                self.origin.position.y + self.width * self.resolution,
+                e))
+
+    def get_cost_from_costmap_x_y(self, x, y):
+        if self.is_in_gridmap(x, y):
+            # data comes in row-major order http://docs.ros.org/en/melodic/api/nav_msgs/html/msg/OccupancyGrid.html
+            # first index is the row, second index the column
+            return self._grid_data[y][x]
+        else:
+            raise IndexError(
+                "Coordinates out of gridmap, x: {}, y: {} must be in between: [0, {}], [0, {}]".format(
+                    x, y, self.height, self.width))
+
+    def is_in_gridmap(self, x, y):
+        if -1 < x < self.width and -1 < y < self.height:
+            return True
+        else:
+            return False
+
+    def get_closest_cell_under_cost(self, x, y, cost_threshold, max_radius):
+        """
+        Looks from closest to furthest in a circular way for the first cell
+        with a cost under cost_threshold up until a distance of max_radius,
+        useful to find closest free cell.
+        returns -1, -1 , -1 if it was not found.
+
+        :param x int: x coordinate to look from
+        :param y int: y coordinate to look from
+        :param cost_threshold int: maximum threshold to look for
+        :param max_radius int: maximum number of cells around to check
+        """
+        return self._get_closest_cell_arbitrary_cost(
+            x, y, cost_threshold, max_radius, bigger_than=False)
+
+    def get_closest_cell_over_cost(self, x, y, cost_threshold, max_radius):
+        """
+        Looks from closest to furthest in a circular way for the first cell
+        with a cost over cost_threshold up until a distance of max_radius,
+        useful to find closest obstacle.
+        returns -1, -1, -1 if it was not found.
+
+        :param x int: x coordinate to look from
+        :param y int: y coordinate to look from
+        :param cost_threshold int: minimum threshold to look for
+        :param max_radius int: maximum number of cells around to check
+        """
+        return self._get_closest_cell_arbitrary_cost(
+            x, y, cost_threshold, max_radius, bigger_than=True)
+
+    def _get_closest_cell_arbitrary_cost(self, x, y,
+                                         cost_threshold, max_radius,
+                                         bigger_than=False):
+
+        # Check the actual goal cell
+        try:
+            cost = self.get_cost_from_costmap_x_y(x, y)
+        except IndexError:
+            return None
+
+        if bigger_than:
+            if cost > cost_threshold:
+                return x, y, cost
+        else:
+            if cost < cost_threshold:
+                return x, y, cost
+
+        def create_radial_offsets_coords(radius):
+            """
+            Creates an ordered by radius (without repetition)
+            generator of coordinates to explore around an initial point 0, 0
+
+            For example, radius 2 looks like:
+            [(-1, -1), (-1, 0), (-1, 1), (0, -1),  # from radius 1
+            (0, 1), (1, -1), (1, 0), (1, 1),  # from radius 1
+            (-2, -2), (-2, -1), (-2, 0), (-2, 1),
+            (-2, 2), (-1, -2), (-1, 2), (0, -2),
+            (0, 2), (1, -2), (1, 2), (2, -2),
+            (2, -1), (2, 0), (2, 1), (2, 2)]
+            """
+            # We store the previously given coordinates to not repeat them
+            # we use a Dict as to take advantage of its hash table to make it more efficient
+            coords = {}
+            # iterate increasing over every radius value...
+            for r in range(1, radius + 1):
+                # for this radius value... (both product and range are generators too)
+                tmp_coords = product(range(-r, r + 1), repeat=2)
+                # only yield new coordinates
+                for i, j in tmp_coords:
+                    if (i, j) != (0, 0) and not coords.get((i, j), False):
+                        coords[(i, j)] = True
+                        yield (i, j)
+
+        coords_to_explore = create_radial_offsets_coords(max_radius)
+
+        for idx, radius_coords in enumerate(coords_to_explore):
+            # for coords in radius_coords:
+            tmp_x, tmp_y = radius_coords
+            # print("Checking coords: " +
+            #       str((x + tmp_x, y + tmp_y)) +
+            #       " (" + str(idx) + " / " + str(len(coords_to_explore)) + ")")
+            try:
+                cost = self.get_cost_from_costmap_x_y(x + tmp_x, y + tmp_y)
+            # If accessing out of grid, just ignore
+            except IndexError:
+                pass
+            if bigger_than:
+                if cost > cost_threshold:
+                    return x + tmp_x, y + tmp_y, cost
+
+            else:
+                if cost < cost_threshold:
+                    return x + tmp_x, y + tmp_y, cost
+
+        return -1, -1, -1
+
+class OccupancyChecker:
+    def __init__(self, action_name, map_topic):
+        self.ogm = OccupancyGridManager(map_topic)
+        self.server = actionlib.SimpleActionServer(action_name, OccupancyCheckerAction, self.execute, False)
+        self.server.start()
+
+    def execute(self, goal):
+        search_radius_in_cells = int(round(goal.search_radius / self.ogm.resolution))
+        result = OccupancyCheckerResult()
+        for point in goal.points:
+            costmap_point = self.ogm.get_costmap_x_y(point.x, point.y)
+            dist_to_obstacle = self.ogm.get_closest_cell_over_cost(costmap_point[0], costmap_point[1], 50, search_radius_in_cells)[2]
+            result.far_from_obstacle.append(dist_to_obstacle == -1)
+        self.server.set_succeeded(result)
+
+if __name__ == '__main__':
+    rospy.init_node('OccupancyChecker')
+
+    # get action server name
+    action_name = rospy.get_param('~action_name', None)
+    if not action_name:
+        raise ValueError('param "action_name" not specified')
+
+    # get map topic
+    map_topic = rospy.get_param('~map_topic', None)
+    if not map_topic:
+        raise ValueError('param "map_topic" not specified')
+
+    server = OccupancyChecker(action_name, map_topic)
+    rospy.spin()


### PR DESCRIPTION
This PR adds a new action_server called `OccupancyChecker`. The action server can be used to query if a set of points (in the `map` frame) lie close to an occupied cell in an occupancy grid map. The request to the action_server can be made using the `OccupancyCheckerAction` messages, whose goal consists of a list of points to be checked and a search radius (in meters) for the neighboring cells.

The actual class that does the checking for occupied cells was taken as-is from [here](https://github.com/awesomebytes/occupancy_grid_python/tree/1034fc18912e57d4ba643ac547256dfbd4f5945b/src/occupancy_grid_python)

## Related PRs
Related to https://github.com/b-it-bots/mas_domestic_robotics/pull/248

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
