### PR TITLE
Feature/object cloud to robot scan converter

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,8 @@
   <build_depend>nav_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>pcl_ros</build_depend>
+  <build_depend>ira_laser_tools</build_depend>
+  <build_depend>pointcloud_to_laserscan</build_depend>
 
   <exec_depend>actionlib</exec_depend>
   <exec_depend>actionlib_msgs</exec_depend>

--- a/ros/launch/object_cloud_to_scan_converter.launch
+++ b/ros/launch/object_cloud_to_scan_converter.launch
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<launch>
+    <!-- Cloud to scan node parameters -->
+    <arg name="obstacle_cloud_in_topic"/>
+    <arg name="obstacle_cloud_to_scan_topic" default="obstacle_scan"/>
+    <arg name="scan_target_frame" default="base_link"/>
+
+    <!-- Scan merger node parameters -->
+    <arg name="merge_robot_and_object_scans" default="true"/>
+    <arg name="laser_scan_merger_start_delay" default="10.0" /> <!-- This is needed as the merger node has to wait until the cloud_to_scan starts publishing on the scan topic -->
+    <arg name="merged_scan_topic" default="merged_scan"/>
+    <arg name="robot_scan_topic" default="/hsrb/base_scan"/>
+
+    <!-- Start the node to convert point clouds to laser scan -->
+    <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="pointcloud_to_laserscan_node" output="screen"
+          ns="mas_navigation_tools">
+        <remap from="cloud_in" to="$(arg obstacle_cloud_in_topic)" />
+        <remap from="scan" to="$(arg obstacle_cloud_to_scan_topic)" />
+        <param name="target_frame" value="$(arg scan_target_frame)" />
+    </node>
+
+    <!-- Merge the simulated object scans with the robot's base scan -->
+    <node pkg="ira_laser_tools" name="laserscan_multi_merger" type="laserscan_multi_merger" output="screen" ns="mas_navigation_tools" 
+          if="$(arg merge_robot_and_object_scans)" launch-prefix="bash -c 'sleep $(arg laser_scan_merger_start_delay); $0 $@' ">
+       <param name="destination_frame" value="base_range_sensor_link" />
+       <param name="cloud_destination_topic" value="merged_cloud" />
+       <param name="scan_destination_topic"  value="$(arg merged_scan_topic)" />
+       <param name="laserscan_topics" value="/mas_navigation_tools/$(arg obstacle_cloud_to_scan_topic) $(arg robot_scan_topic) " />
+    </node>
+</launch>


### PR DESCRIPTION
This PR adds a new launch file that can start two nodes:
    1. A `cloud_to_scan` node, that converts an input point cloud to a laser scan
    2. A `scan_merger` node, that merges the scan generated from the point cloud with the robot's laser scan.

This setup can be used in conjunction with the new `cloud object detector` introduced in https://github.com/b-it-bots/mas_domestic_robotics/pull/248 to detect the small objects lying on the ground as if they were detected by the base laser scan of the robot

## Related PRs
Related to https://github.com/b-it-bots/mas_domestic_robotics/pull/248

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
